### PR TITLE
Fix typo in qlatin1string-non-ascii

### DIFF
--- a/src/checks/level1/qlatin1string-non-ascii.cpp
+++ b/src/checks/level1/qlatin1string-non-ascii.cpp
@@ -47,5 +47,5 @@ void QLatin1StringNonAscii::VisitStmt(clang::Stmt *stmt)
 
     StringLiteral *lt = clazy::getFirstChildOfType2<StringLiteral>(stmt);
     if (lt && !Utils::isAscii(lt))
-        emitWarning(stmt, "QStringLiteral with non-ascii literal");
+        emitWarning(stmt, "QLatin1String with non-ascii literal");
 }


### PR DESCRIPTION
It is a QLatin1String, not a QStringLiteral.